### PR TITLE
Fix @vercel/postgres to use DATABASE_URL consistently

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,13 +1,14 @@
 // lib/db.ts
-import { createPool } from '@vercel/postgres';
+import { sql } from '@vercel/postgres';
 import { ShortenedUrl } from '@/types';
 
-// DATABASE_URLを使用してプールを作成
-const pool = createPool({
-  connectionString: process.env.DATABASE_URL
-});
+// DATABASE_URLが設定されていることを確認
+if (!process.env.DATABASE_URL) {
+  throw new Error('DATABASE_URL environment variable is not set');
+}
 
-const { sql } = pool;
+// POSTGRES_URLをDATABASE_URLに設定（@vercel/postgresが使用するため）
+process.env.POSTGRES_URL = process.env.DATABASE_URL;
 
 // データベースの初期化
 export async function initializeDatabase(): Promise<void> {

--- a/scripts/check-db.js
+++ b/scripts/check-db.js
@@ -2,20 +2,20 @@
 // 環境変数を読み込む
 require('dotenv').config({ path: '.env.local' });
 
-const { createPool } = require('@vercel/postgres');
+const { sql } = require('@vercel/postgres');
 
-// DATABASE_URLを使用してプールを作成
-const pool = createPool({
-  connectionString: process.env.DATABASE_URL
-});
+// DATABASE_URLが設定されていることを確認
+if (!process.env.DATABASE_URL) {
+  throw new Error('DATABASE_URL environment variable is not set');
+}
 
-const { sql } = pool;
+// POSTGRES_URLをDATABASE_URLに設定（@vercel/postgresが使用するため）
+process.env.POSTGRES_URL = process.env.DATABASE_URL;
 
 async function checkDatabase() {
   try {
     console.log('🔄 データベース接続のテスト中...');
     console.log('DATABASE_URL:', process.env.DATABASE_URL?.substring(0, 30) + '...');
-    console.log('POSTGRES_URL:', process.env.POSTGRES_URL?.substring(0, 30) + '...');
     
     // 接続テスト
     const testResult = await sql`SELECT 1 as test`;


### PR DESCRIPTION
## Summary
- Fix @vercel/postgres configuration to use DATABASE_URL by setting POSTGRES_URL internally
- Modify lib/db.ts to use DATABASE_URL with proper error handling
- Update scripts/check-db.js to use the same approach
- Simplify environment variable management by using only DATABASE_URL

## Changes Made
- **lib/db.ts**: Replace createPool approach with direct sql import and internal POSTGRES_URL assignment
- **scripts/check-db.js**: Apply the same pattern for consistency
- **Error Handling**: Add validation for missing DATABASE_URL environment variable
- **Console Output**: Cleanup to show only DATABASE_URL for consistency

## Technical Details
The `@vercel/postgres` library expects `POSTGRES_URL` environment variable, but we want to use `DATABASE_URL` which is already configured in our environment. This PR addresses this by internally setting `process.env.POSTGRES_URL = process.env.DATABASE_URL` in both the main library and test script.

## Benefits
- ✅ Eliminates dependency on POSTGRES_URL environment variable
- ✅ Uses existing DATABASE_URL configuration
- ✅ Provides clear error messaging for missing environment variables
- ✅ Maintains consistent approach across lib and scripts
- ✅ Verified working through local testing

## Test Results
✅ **Database Connection Test**: Successfully connects and queries
✅ **API Endpoint `/api/shorten`**: Creates short URLs correctly
✅ **Redirect Functionality**: Both ID-based and custom path redirects work
✅ **Build Process**: No errors during Next.js build

## Test plan
- [x] Database connection test script runs successfully
- [x] API endpoints function correctly (tested with curl)
- [x] Redirect functionality works for both ID and custom paths
- [x] No errors in development server logs
- [x] Clean build with no environment variable errors

🤖 Generated with [Claude Code](https://claude.ai/code)